### PR TITLE
fix dependency handling in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ ensure_docker() {
         log "Docker not installed, installing ..."
         curl -sSL https://get.docker.com | sh
         sudo usermod -aG docker $USER
+        newgrp docker
     fi
 
     docker_version=`docker --version`
@@ -75,10 +76,9 @@ ensure_git() {
 
 ensure_docker_compose() {
     log "Checking for docker-compose ..."
-    docker_compose_status=`which docker-compose`
-    if [ $? -ne 0 ]; then
+    if ! [ -x "$(command -v docker-compose)" ]; then
         log "docker-compose not installed, installing ..."
-        sudo pip3 install docker-compose
+        sudo apt-get install -y docker-compose
     fi
 
     docker_compose=`docker-compose --version`


### PR DESCRIPTION
Fixed some issues in the install script:

- added `newgrp docker` after `usermod` call in order to allow testing/running docker without root after first install. Otherwise the docker test fails.
- change conditional check for `docker-compose`, since previous version would bailout if `docker-compose` was not already installed (due to `set -e` at top of script)
- install `docker-compose` with `apt-get` instead of `pip3`, which can help with dependency handling since `docker-compose` is no longer maintained on PyPI and install often fails with `pip3` due to dependency issues (e.g. newer PyYAML).

Also note that [`docker-compose`](https://pypi.org/project/docker-compose/) (v1) is now deprecated and no longer maintained compared to [`docker compose` ](https://github.com/docker/compose) (v2), but I haven't tested switching berrypatch to the newer version (yet).